### PR TITLE
Feature/agents

### DIFF
--- a/backend/agents/jn_agent.py
+++ b/backend/agents/jn_agent.py
@@ -7,6 +7,7 @@ from typing import Dict, Any
 
 # Importar los esquemas Pydantic desde backend.models
 from backend.models.schemas_jn import (
+    ContextIn,
     JustificacionNecesidadStructured,
     ObjetoAlcance,
     ContextoProblema,
@@ -20,14 +21,19 @@ from backend.models.schemas_jn import (
 
 # Importar los prompts desde backend.prompts
 from backend.prompts.jn_prompts import prompt_a_template, prompt_b_template
-
-# Cargar variables de entorno
-load_dotenv()
+from backend.core.config import settings 
 
 # --- Configuración de los modelos de lenguaje ---
 # Asegúrate de que OPENAI_API_KEY y GROQ_API_KEY estén en tu .env
-llm_openai = ChatOpenAI(model="gpt-5", temperature=0) # Puedes cambiar el modelo si lo deseas
-llm_groq = ChatGroq(model="gpt-oss-120b", temperature=0) # Puedes cambiar el modelo si lo deseas
+
+async def generate_justificacion_necesidad(
+    user_input: ContextIn,
+    structured_llm_choice: str = "openai",
+    narrative_llm_choice: str = "openai"
+) -> JustificacionNecesidadStructured:
+    # Configuración de los modelos de lenguaje
+    llm_openai = ChatOpenAI(model="gpt-5", temperature=0, api_key=settings.openai_api_key) # Usar settings.openai_api_key
+    llm_groq = ChatGroq(model="gpt-oss-120b", temperature=0, api_key=settings.groq_api_key) # Usar settings.groq_api_key
 
 # --- Prompt A: Generador de datos estructurados ---
 # Este prompt toma la información de entrada y la estructura según el esquema Pydantic.

--- a/backend/agents/jn_agent.py
+++ b/backend/agents/jn_agent.py
@@ -1,0 +1,86 @@
+import os
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langchain_groq import ChatGroq
+from langchain_core.output_parsers import JsonOutputParser
+from typing import Dict, Any
+
+# Importar los esquemas Pydantic desde backend.models
+from backend.models.schemas_jn import (
+    JustificacionNecesidadStructured,
+    ObjetoAlcance,
+    ContextoProblema,
+    Objetivos,
+    AlternativasConsideradas,
+    TipoContratoProcedimiento,
+    PresupuestoFinanciacion,
+    PlazoHitos,
+    RiesgosMitigacion
+)
+
+# Importar los prompts desde backend.prompts
+from backend.prompts.jn_prompts import prompt_a_template, prompt_b_template
+
+# Cargar variables de entorno
+load_dotenv()
+
+# --- Configuración de los modelos de lenguaje ---
+# Asegúrate de que OPENAI_API_KEY y GROQ_API_KEY estén en tu .env
+llm_openai = ChatOpenAI(model="gpt-5", temperature=0) # Puedes cambiar el modelo si lo deseas
+llm_groq = ChatGroq(model="gpt-oss-120b", temperature=0) # Puedes cambiar el modelo si lo deseas
+
+# --- Prompt A: Generador de datos estructurados ---
+# Este prompt toma la información de entrada y la estructura según el esquema Pydantic.
+parser_structured_jn = JsonOutputParser(pydantic_object=JustificacionNecesidadStructured)
+
+# Las cadenas ahora se definirán dentro de la función para permitir la selección dinámica del LLM
+# chain_prompt_a = prompt_a_template | llm_openai | parser_structured_jn # Eliminado de aquí
+# chain_prompt_b_openai = prompt_b_template | llm_openai # Eliminado de aquí
+# chain_prompt_b_groq = prompt_b_template | llm_groq # Eliminado de aquí
+
+async def generate_justificacion_necesidad(
+    user_input: Dict[str, Any],
+    structured_llm_choice: str = "openai", # 'openai' o 'groq' para la estructuración
+    narrative_llm_choice: str = "groq" # 'openai' o 'groq' para la narrativa
+) -> Dict[str, Any]:
+    """
+    Genera la Justificación de la Necesidad en dos pasos:
+    1. Estructura los datos de entrada (Prompt A).
+    2. Genera la narrativa a partir de los datos estructurados (Prompt B).
+
+    Args:
+        user_input: Un diccionario con la información proporcionada por el usuario.
+        structured_llm_choice: Elige el LLM para la generación de datos estructurados ('openai' o 'groq').
+        narrative_llm_choice: Elige el LLM para la generación de la narrativa ('openai' o 'groq').
+
+    Returns:
+        Un diccionario con los datos estructurados y la narrativa generada.
+    """
+    # Seleccionar LLM para la estructuración
+    if structured_llm_choice == "groq":
+        structured_llm = llm_groq
+    else: # Por defecto o si no es 'groq', usa openai
+        structured_llm = llm_openai
+
+    chain_prompt_a = prompt_a_template | structured_llm | parser_structured_jn
+
+    # Paso 1: Generar datos estructurados (Prompt A)
+    structured_data = await chain_prompt_a.ainvoke(
+        {"user_input": user_input, "format_instructions": parser_structured_jn.get_format_instructions()}
+    )
+
+    # Seleccionar LLM para la narrativa
+    if narrative_llm_choice == "groq":
+        narrative_llm = llm_groq
+    else: # Por defecto o si no es 'groq', usa openai
+        narrative_llm = llm_openai
+
+    narrative_chain = prompt_b_template | narrative_llm
+
+    # Paso 2: Generar narrativa (Prompt B)
+    narrative_output = await narrative_chain.ainvoke({"structured_data": structured_data})
+
+    return {
+        "structured_data": structured_data,
+        "narrative": narrative_output.content # Acceder al contenido de la respuesta del LLM
+    }

--- a/backend/api/jn_routes.py
+++ b/backend/api/jn_routes.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import Any, Optional, Dict
+from backend.models.schemas_jn import ContextIn
+from backend.core.logic_jn import build_jn_output
+from backend.agents.jn_agent import generate_justificacion_necesidad
+
+router = APIRouter(prefix="/justificacion", tags=["justificacion"])
+
+# Modelo de entrada para la API
+class GenerateJNRequest(BaseModel):
+    user_input: Dict[str, Any] = Field(..., description="Datos de entrada proporcionados por el usuario para generar la JN.")
+    structured_llm_choice: str = Field("openai", description="Elige el LLM para la generación de datos estructurados ('openai' o 'groq').")
+    narrative_llm_choice: str = Field("groq", description="Elige el LLM para la generación de la narrativa ('openai' o 'groq').")
+
+@router.post("/de_la_necesidad")
+async def justificacion_de_la_necesidad(ctx: ContextIn):
+    return await build_jn_output(ctx.dict())
+
+@router.post("/generar_jn")
+async def generar_justificacion_de_la_necesidad(request: GenerateJNRequest):
+    """
+    Genera la Justificación de la Necesidad (JN) en formato estructurado y narrativo.
+    Permite seleccionar el LLM a utilizar para cada etapa.
+    """
+    if request.structured_llm_choice not in ["openai", "groq"]:
+        raise HTTPException(status_code=400, detail="structured_llm_choice debe ser 'openai' o 'groq'")
+    if request.narrative_llm_choice not in ["openai", "groq"]:
+        raise HTTPException(status_code=400, detail="narrative_llm_choice debe ser 'openai' o 'groq'")
+
+    try:
+        jn_output = await generate_justificacion_necesidad(
+            user_input=request.user_input,
+            structured_llm_choice=request.structured_llm_choice,
+            narrative_llm_choice=request.narrative_llm_choice
+        )
+        return jn_output
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error al generar la JN: {str(e)}")

--- a/backend/api/jn_routes.py
+++ b/backend/api/jn_routes.py
@@ -9,7 +9,7 @@ router = APIRouter(prefix="/justificacion", tags=["justificacion"])
 
 # Modelo de entrada para la API
 class GenerateJNRequest(BaseModel):
-    user_input: Dict[str, Any] = Field(..., description="Datos de entrada proporcionados por el usuario para generar la JN.")
+    user_input: ContextIn = Field(..., description="Datos de entrada proporcionados por el usuario para generar la JN.")
     structured_llm_choice: str = Field("openai", description="Elige el LLM para la generación de datos estructurados ('openai' o 'groq').")
     narrative_llm_choice: str = Field("groq", description="Elige el LLM para la generación de la narrativa ('openai' o 'groq').")
 

--- a/backend/api/routes_jn.py
+++ b/backend/api/routes_jn.py
@@ -1,9 +1,0 @@
-from fastapi import APIRouter
-from backend.models.schemas_jn import ContextIn
-from backend.core.logic_jn import build_jn_output
-
-router = APIRouter(prefix="/justificacion", tags=["justificacion"])
-
-@router.post("/de_la_necesidad")
-async def justificacion_de_la_necesidad(ctx: ContextIn):
-    return await build_jn_output(ctx.dict())

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,4 +1,7 @@
 from pydantic_settings import BaseSettings
+from dotenv import load_dotenv # Importar load_dotenv
+
+load_dotenv() # Añadir esta línea para cargar las variables de entorno
 
 class Settings(BaseSettings):
     app_name: str = "Pliegos Públicos API"

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -2,5 +2,6 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     app_name: str = "Pliegos Públicos API"
-
+    openai_api_key: str
+    groq_api_key: str
 settings = Settings()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from backend.api.routes_jn import router as jn_router
+from backend.api.jn_routes import router as jn_router
 from backend.core.config import settings
 
 app = FastAPI(title=settings.app_name)

--- a/backend/models/schemas_jn.py
+++ b/backend/models/schemas_jn.py
@@ -11,3 +11,30 @@ class ContextIn(BaseModel):
     locale_meta_json: Optional[Any] = None
     data_schema_json: Optional[Any] = None
     hash_prev: Optional[str] = None
+
+class JustificacionNecesidadStructured(BaseModel):
+    justificacion: str
+
+class ObjetoAlcance(BaseModel):
+    nombre: str
+
+class ContextoProblema(BaseModel):
+    descripcion: str
+
+class Objetivos(BaseModel):
+    descripcion: str
+
+class AlternativasConsideradas(BaseModel):
+    descripcion: str
+
+class TipoContratoProcedimiento(BaseModel):
+    descripcion: str
+
+class PresupuestoFinanciacion(BaseModel):
+    descripcion: str
+
+class PlazoHitos(BaseModel):
+    descripcion: str
+
+class RiesgosMitigacion(BaseModel):
+    descripcion: str

--- a/backend/prompts/jn_prompts.py
+++ b/backend/prompts/jn_prompts.py
@@ -1,0 +1,19 @@
+from langchain_core.prompts import ChatPromptTemplate
+
+# --- Prompt A: Generador de datos estructurados ---
+# Este prompt toma la información de entrada y la estructura según el esquema Pydantic.
+prompt_a_template = ChatPromptTemplate.from_messages(
+    [
+        ("system", "Eres un asistente experto en la redacción de Justificaciones de la Necesidad para licitaciones públicas. Tu tarea es extraer y estructurar la información proporcionada por el usuario en un formato JSON que cumpla estrictamente con el siguiente esquema Pydantic:\n\n{format_instructions}\n\nSi algún campo no puede ser inferido de la información proporcionada, déjalo como nulo o vacío según el tipo de dato, pero no inventes información crítica. Asegúrate de que el JSON sea válido y completo según el esquema."),
+        ("human", "Genera la Justificación de la Necesidad con la siguiente información:\n\n{user_input}"),
+    ]
+)
+
+# --- Prompt B: Redactor técnico-administrativo ---
+# Este prompt toma los datos estructurados y genera la narrativa final.
+prompt_b_template = ChatPromptTemplate.from_messages(
+    [
+        ("system", "Eres un redactor técnico-administrativo. Tu tarea es transformar los datos estructurados de una Justificación de la Necesidad en una narrativa coherente, formal y profesional. El tono debe ser administrativo y neutro. Cita las fuentes o datos relevantes cuando sea necesario. Genera la narrativa en formato JSON, donde cada sección sea un párrafo o conjunto de párrafos bajo una clave descriptiva (ej. 'objeto_alcance_narrativa', 'contexto_problema_narrativa')."),
+        ("human", "Genera la narrativa de la Justificación de la Necesidad a partir de los siguientes datos estructurados:\n\n{structured_data}"),
+    ]
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,9 @@ uvicorn
 pydantic-settings
 python-dotenv
 pymongo
+groq
+openai
+langchain
+langchain-groq
+langchain-openai
+pydantic


### PR DESCRIPTION
Esta Pull Request introduce mejoras significativas en la gestión de las claves de API y la flexibilidad en la selección de Modelos de Lenguaje Grandes (LLM) para la generación de Justificaciones de la Necesidad (JN).

Contexto y Motivación: El objetivo principal es proporcionar una configuración más robusta y segura para las claves de API, así como permitir a los usuarios elegir dinámicamente entre diferentes proveedores de LLM (OpenAI y Groq) para optimizar el rendimiento y los costos según las necesidades específicas de cada etapa de generación.

Cambios Clave Incluidos:

1. 1. Gestión de Claves de API:
   
   - Configuración Centralizada : Se ha modificado la clase Settings en `config.py` para incluir openai_api_key y groq_api_key , asegurando que todas las claves de API se carguen de forma consistente desde el archivo .env .
   - Carga de Variables de Entorno : Se añadió load_dotenv() directamente en `config.py` para garantizar que las variables de entorno se carguen correctamente antes de la inicialización de la configuración.
   - Uso Consistente : `jn_agent.py` ahora accede a las claves de API a través del objeto settings , eliminando dependencias directas de load_dotenv() en el agente.
2. 2. Selector Dinámico de LLM:
   
   - Flexibilidad en jn_agent.py : La función generate_justificacion_necesidad en `jn_agent.py` ahora acepta structured_llm_choice y narrative_llm_choice como parámetros, permitiendo seleccionar entre ChatOpenAI y ChatGroq para la generación estructurada y narrativa, respectivamente.
   - Corrección de Modelo Groq : Se genero el modelo con Groq (ej. "gpt-oss-120b" ) para asegurar la compatibilidad y el correcto funcionamiento.
   - Actualización de Prompts : Se corrigió un ImportError en `jn_agent.py` al cambiar las importaciones de structured_data_prompt y narrative_prompt a prompt_a_template y prompt_b_template , que son los nombres correctos definidos en `jn_prompts.py` .
3. 3. Actualizaciones en la API:
   
   - Endpoint /generar_jn : El endpoint en `jn_routes.py` ahora permite al usuario especificar structured_llm_choice y narrative_llm_choice en la solicitud, habilitando la selección de LLM a través de la API.
   - Consistencia de Tipos : Se ajustó el tipo de user_input en la clase GenerateJNRequest de Dict[str, Any] a ContextIn para asegurar la coherencia con la función generate_justificacion_necesidad .
Beneficios:

- Mayor Flexibilidad : Permite a los usuarios elegir el LLM más adecuado para cada tarea, optimizando el rendimiento y los costos.
- Configuración Robusta : Mejora la seguridad y la fiabilidad en la carga de las claves de API.
- Código Más Limpio : Resuelve errores de importación y duplicidad de funciones, haciendo el código más mantenible.
Cómo Probar:

1. 1. Asegúrate de tener un archivo .env en la raíz del proyecto con OPENAI_API_KEY y GROQ_API_KEY configuradas.
2. 2. Inicia la aplicación.
```
uvicorn backend.main:app --reload
```
3. 3. Envía una solicitud POST al endpoint /justificacion/generar_jn con los campos structured_llm_choice y narrative_llm_choice (ej. "openai" o "groq" ) en el cuerpo de la solicitud, junto con el user_input de tipo ContextIn .