### PR TITLE
Implementar repositorio de salidas, persistencia automática y nuevos puntos finales de API

### DIFF
--- a/backend/api/jn_routes.py
+++ b/backend/api/jn_routes.py
@@ -4,6 +4,7 @@ from backend.models.schemas_jn import UserRequest
 from backend.core.logic_jn import build_jn_output
 from backend.agents.jn_agent import generate_justificacion_necesidad
 from backend.database.outputs_repository import save_output  # ✅ import único
+from backend.utils.dict_utils import to_dict_safe
 
 router = APIRouter(prefix="/justificacion", tags=["justificacion"])
 
@@ -42,7 +43,7 @@ async def generar_justificacion_de_la_necesidad(request: GenerateJNRequest):
 
         # --- Guardado flexible ---
         if "json_a" in jn_output:
-            json_a_dict = jn_output["json_a"].dict() if hasattr(jn_output["json_a"], "dict") else jn_output["json_a"]
+            json_a_dict = to_dict_safe(jn_output["json_a"])
             await save_output(
                 expediente_id,
                 documento,
@@ -52,7 +53,7 @@ async def generar_justificacion_de_la_necesidad(request: GenerateJNRequest):
             )
 
         if "json_b" in jn_output:
-            json_b_dict = jn_output["json_b"].dict() if hasattr(jn_output["json_b"], "dict") else jn_output["json_b"]
+            json_b_dict = to_dict_safe(jn_output["json_b"])
             await save_output(
                 expediente_id,
                 documento,
@@ -61,14 +62,15 @@ async def generar_justificacion_de_la_necesidad(request: GenerateJNRequest):
                 json_b_dict
             )
 
-        # fallback → si no está dividido, guardamos todo como nodo B
+        # fallback → si no está dividido
         if "json_a" not in jn_output and "json_b" not in jn_output:
+            jn_output_dict = to_dict_safe(jn_output)
             await save_output(
                 expediente_id,
                 documento,
                 request.user_input.seccion,
                 "B",
-                jn_output
+                jn_output_dict
             )
 
         return jn_output

--- a/backend/api/jn_routes.py
+++ b/backend/api/jn_routes.py
@@ -1,10 +1,9 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
-from typing import Any, Optional, Dict
 from backend.models.schemas_jn import UserRequest
 from backend.core.logic_jn import build_jn_output
 from backend.agents.jn_agent import generate_justificacion_necesidad
-from backend.database.outputs_repository import save_output
+from backend.database.outputs_repository import save_output  # ✅ import único
 
 router = APIRouter(prefix="/justificacion", tags=["justificacion"])
 
@@ -18,9 +17,6 @@ class GenerateJNRequest(BaseModel):
 async def justificacion_de_la_necesidad(ctx: UserRequest):
     return await build_jn_output(ctx.dict())
 
-from backend.database.outputs_repository import save_output  # 👈 importar función
-
-from backend.database.outputs_repository import save_output  # 👈 asegúrate de importar esto
 
 @router.post("/generar_jn")
 async def generar_justificacion_de_la_necesidad(request: GenerateJNRequest):
@@ -63,16 +59,6 @@ async def generar_justificacion_de_la_necesidad(request: GenerateJNRequest):
                 json_b_dict.get("seccion", request.user_input.seccion),
                 "B",
                 json_b_dict
-            )
-
-
-        if "json_b" in jn_output:
-            await save_output(
-                expediente_id,
-                documento,
-                jn_output["json_b"].get("seccion", request.user_input.seccion),
-                "B",
-                jn_output["json_b"]
             )
 
         # fallback → si no está dividido, guardamos todo como nodo B

--- a/backend/api/jn_routes.py
+++ b/backend/api/jn_routes.py
@@ -46,13 +46,25 @@ async def generar_justificacion_de_la_necesidad(request: GenerateJNRequest):
 
         # --- Guardado flexible ---
         if "json_a" in jn_output:
+            json_a_dict = jn_output["json_a"].dict() if hasattr(jn_output["json_a"], "dict") else jn_output["json_a"]
             await save_output(
                 expediente_id,
                 documento,
-                jn_output["json_a"].get("seccion", request.user_input.seccion),
+                json_a_dict.get("seccion", request.user_input.seccion),
                 "A",
-                jn_output["json_a"]
+                json_a_dict
             )
+
+        if "json_b" in jn_output:
+            json_b_dict = jn_output["json_b"].dict() if hasattr(jn_output["json_b"], "dict") else jn_output["json_b"]
+            await save_output(
+                expediente_id,
+                documento,
+                json_b_dict.get("seccion", request.user_input.seccion),
+                "B",
+                json_b_dict
+            )
+
 
         if "json_b" in jn_output:
             await save_output(

--- a/backend/api/jn_routes.py
+++ b/backend/api/jn_routes.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, Field
 from backend.models.schemas_jn import UserRequest
 from backend.core.logic_jn import build_jn_output
 from backend.agents.jn_agent import generate_justificacion_necesidad
-from backend.database.outputs_repository import save_output  # ✅ import único
+from backend.database.outputs_repository import save_output
 from backend.utils.dict_utils import to_dict_safe
 
 router = APIRouter(prefix="/justificacion", tags=["justificacion"])

--- a/backend/api/routes_outputs.py
+++ b/backend/api/routes_outputs.py
@@ -3,11 +3,12 @@ from backend.database.mongo import get_collection
 
 router = APIRouter(prefix="/outputs", tags=["outputs"])
 
+
 @router.get("/{expediente_id}")
 async def get_outputs(expediente_id: str):
     """
     Devuelve todos los outputs asociados a un expediente.
-    Sirve como ledger completo del expediente.
+    Ledger completo: incluye todas las secciones, nodos (A/B) y versiones.
     """
     try:
         collection = get_collection("outputs")
@@ -25,9 +26,9 @@ async def get_outputs(expediente_id: str):
 @router.get("/{expediente_id}/{seccion}/{nodo}")
 async def get_output_by_section(expediente_id: str, seccion: str, nodo: str):
     """
-    Devuelve un output específico (ej. JSON_A o JSON_B) de un expediente.
+    Devuelve un output específico de un expediente:
     - expediente_id: ID del expediente
-    - seccion: sección del documento (ej. JN.1, JN.2)
+    - seccion: sección del documento (ej. JN.1, JN.2, …)
     - nodo: "A" (estructurado) o "B" (narrativa)
     """
     try:
@@ -41,3 +42,33 @@ async def get_output_by_section(expediente_id: str, seccion: str, nodo: str):
         return doc
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error recuperando output: {str(e)}")
+
+
+@router.get("/{expediente_id}/latest")
+async def get_latest_outputs(expediente_id: str):
+    """
+    Devuelve la última narrativa (nodo B) de cada sección de un expediente.
+    Pensado para frontend: vista resumida y lista para revisión/exportación.
+    """
+    try:
+        collection = get_collection("outputs")
+
+        # Traer solo nodo B, ordenado por timestamp descendente
+        cursor = collection.find(
+            {"expediente_id": expediente_id, "nodo": "B"},
+            {"_id": 0}
+        ).sort("timestamp", -1)
+
+        latest_by_section = {}
+        async for doc in cursor:
+            seccion = doc["seccion"]
+            if seccion not in latest_by_section:
+                latest_by_section[seccion] = doc["narrativa"]
+
+        return {
+            "expediente_id": expediente_id,
+            "documento": "JN",
+            "secciones": latest_by_section
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error recuperando últimas narrativas: {str(e)}")

--- a/backend/api/routes_outputs.py
+++ b/backend/api/routes_outputs.py
@@ -73,12 +73,13 @@ async def get_latest_outputs(expediente_id: str):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error recuperando últimas narrativas: {str(e)}")
 
-@router.get("/{expediente_id}/jn/final")
-async def get_final_jn(expediente_id: str):
+
+@router.get("/{expediente_id}/jn/assembled")
+async def get_assembled_jn(expediente_id: str):
     """
     Devuelve el documento JN ensamblado a partir de las últimas narrativas (nodo B)
-    de cada sección (JN.1, JN.2, ...). Es un documento vivo: devuelve tantas secciones
-    como haya ya generadas para el expediente.
+    de cada sección (JN.1, JN.2, ...). Es un documento vivo y se actualiza a medida
+    que se van generando nuevas secciones.
     """
     try:
         collection = get_collection("outputs")
@@ -97,7 +98,7 @@ async def get_final_jn(expediente_id: str):
                 latest_by_section[seccion] = doc.get("narrativa")
 
         # Ordenamos secciones al estilo JN.1, JN.2...
-        final_sections = [
+        assembled_sections = [
             {"seccion": s, "narrativa": latest_by_section[s]}
             for s in sorted(latest_by_section.keys())
         ]
@@ -105,8 +106,8 @@ async def get_final_jn(expediente_id: str):
         return {
             "expediente_id": expediente_id,
             "documento": "JN",
-            "final": final_sections
+            "assembled": assembled_sections
         }
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error ensamblando JN final: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error ensamblando JN: {str(e)}")

--- a/backend/api/routes_outputs.py
+++ b/backend/api/routes_outputs.py
@@ -1,17 +1,43 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from backend.database.mongo import get_collection
 
 router = APIRouter(prefix="/outputs", tags=["outputs"])
 
-@router.post("/")
-async def create_output(doc: dict):
-    collection = get_collection("outputs")
-    result = await collection.insert_one(doc)
-    return {"inserted_id": str(result.inserted_id)}
-
 @router.get("/{expediente_id}")
 async def get_outputs(expediente_id: str):
-    collection = get_collection("outputs")
-    docs_cursor = collection.find({"expediente_id": expediente_id}, {"_id": 0})
-    docs = [doc async for doc in docs_cursor]
-    return {"data": docs}
+    """
+    Devuelve todos los outputs asociados a un expediente.
+    Sirve como ledger completo del expediente.
+    """
+    try:
+        collection = get_collection("outputs")
+        cursor = collection.find({"expediente_id": expediente_id}, {"_id": 0}).sort([
+            ("seccion", 1),
+            ("nodo", 1),
+            ("timestamp", 1)
+        ])
+        docs = [doc async for doc in cursor]
+        return {"ledger": docs}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error recuperando outputs: {str(e)}")
+
+
+@router.get("/{expediente_id}/{seccion}/{nodo}")
+async def get_output_by_section(expediente_id: str, seccion: str, nodo: str):
+    """
+    Devuelve un output específico (ej. JSON_A o JSON_B) de un expediente.
+    - expediente_id: ID del expediente
+    - seccion: sección del documento (ej. JN.1, JN.2)
+    - nodo: "A" (estructurado) o "B" (narrativa)
+    """
+    try:
+        collection = get_collection("outputs")
+        doc = await collection.find_one(
+            {"expediente_id": expediente_id, "seccion": seccion, "nodo": nodo},
+            {"_id": 0}
+        )
+        if not doc:
+            raise HTTPException(status_code=404, detail="Output no encontrado")
+        return doc
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error recuperando output: {str(e)}")

--- a/backend/database/outputs_repository.py
+++ b/backend/database/outputs_repository.py
@@ -1,0 +1,31 @@
+"""
+Repositorio para gestionar la colección de salidas. Esto garantiza que cada JSON_A y JSON_B generado se conserve con total trazabilidad.
+"""
+
+from backend.database.mongo import get_collection
+from datetime import datetime
+
+async def save_output(expediente_id: str, documento: str, seccion: str, nodo: str, content: dict) -> str:
+    
+    collection = get_collection("outputs")
+
+    doc = {
+        "expediente_id": expediente_id,
+        "documento": documento,
+        "seccion": seccion,
+        "nodo": nodo,
+        "version": content.get("version", 1),
+        "hash": content.get("hash", ""),
+        "hash_prev": content.get("hash_prev", ""),
+        "data": content.get("data", {}),
+        "narrativa": content.get("narrativa", {}),
+        "citas_golden": content.get("citas_golden", []),
+        "citas_normativas": content.get("citas_normativas", []),
+        "dependencias": content.get("dependencias", []),
+        "estado": "final",
+        "timestamp": datetime.utcnow().isoformat(),
+        "raw": content,
+    }
+
+    result = await collection.insert_one(doc)
+    return str(result.inserted_id)

--- a/backend/database/outputs_repository.py
+++ b/backend/database/outputs_repository.py
@@ -1,19 +1,25 @@
 """
-Repositorio para gestionar la colección de salidas. Esto garantiza que cada JSON_A y JSON_B generado se conserve con total trazabilidad.
+Repositorio para gestionar la colección de salidas.
+Esto garantiza que cada JSON_A y JSON_B generado se conserve con total trazabilidad.
 """
 
 from backend.database.mongo import get_collection
 from datetime import datetime
+import uuid 
 
 async def save_output(expediente_id: str, documento: str, seccion: str, nodo: str, content: dict) -> str:
-    
+    """
+    Guarda un output (JSON_A o JSON_B) en la colección `outputs` con trazabilidad completa.
+    """
+
     collection = get_collection("outputs")
 
     doc = {
+        "output_id": str(uuid.uuid4()),  # ID único para trazabilidad
         "expediente_id": expediente_id,
         "documento": documento,
         "seccion": seccion,
-        "nodo": nodo,
+        "nodo": nodo,  # "A" (estructurado) o "B" (narrativa)
         "version": content.get("version", 1),
         "hash": content.get("hash", ""),
         "hash_prev": content.get("hash_prev", ""),

--- a/backend/utils/dict_utils.py
+++ b/backend/utils/dict_utils.py
@@ -1,0 +1,14 @@
+def to_dict_safe(obj):
+    """
+    Convierte un objeto Pydantic u objeto con .dict() / .model_dump() en dict.
+    Si ya es dict, lo devuelve igual.
+    """
+    if hasattr(obj, "model_dump"):  # Pydantic v2
+        return obj.model_dump()
+    elif hasattr(obj, "dict"):     # Pydantic v1
+        return obj.dict()
+    elif isinstance(obj, dict):
+        return obj
+    else:
+        # Fallback: lo convertimos por fuerza con vars()
+        return vars(obj)


### PR DESCRIPTION
### Cambios
- Se añadió `outputs_repository.py` con output_id basado en UUID para trazabilidad.
- Se actualizó `jn_routes.py` para conservar JSON_A y JSON_B en `outputs`.
- Se amplió `routes_outputs.py` con:
- Endpoint de Ledger para el historial completo de expediciones.
- Endpoint para recuperar las últimas narrativas por sección.
- Endpoint ensamblado para narrativas JN concatenadas.
- Endpoint de stub validado para un futuro agente de validación global.

### Notas
- Establece las bases para la integración del validador y el orquestador.
- Mantiene la coherencia con el resumen de Mini-CELIA (trazabilidad + guardrails).
<img width="1487" height="1179" alt="image" src="https://github.com/user-attachments/assets/be9041a4-4df8-4432-8107-56b7c6273ab3" />
<img width="1402" height="833" alt="image" src="https://github.com/user-attachments/assets/68e8150a-7e9f-439b-bc39-c6bbc40b5eb2" />

